### PR TITLE
fixed typo

### DIFF
--- a/bin/install-addons.sh
+++ b/bin/install-addons.sh
@@ -3,7 +3,7 @@
 # ~/.n98-magerun/modules is automatically used by n98-magerun for plugins
 #
 [ -d ~/.n98-magerun/modules/ ] || mkdir -p ~/.n98-magerun/modules/
-[ -d ~/.n98-magerun/modules/mpdm ] || git clone https://github.com/AOEpeople/mpmd.git ~/.n98-magerun/modules/mpmd
+[ -d ~/.n98-magerun/modules/mpmd ] || git clone https://github.com/AOEpeople/mpmd.git ~/.n98-magerun/modules/mpmd
 [ -d ~/.n98-magerun/modules/magerun-addons ] || git clone https://github.com/kalenjordan/magerun-addons.git ~/.n98-magerun/modules/magerun-addons
 #
 # coding standard must be in a directory called "Ecg" anywhere


### PR DESCRIPTION
The typo resulted in the error:

    fatal: Zielpfad '/home/user/.n98-magerun/modules/mpmd' existiert bereits und ist kein leeres Verzeichnis.